### PR TITLE
fix keymap

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,12 +1,12 @@
 [
 	{"keys": ["ctrl+enter"], "command": "antiki"},
 	{"keys": ["enter"], "command": "antiki", "context": [
-		{ "key": "selector", "operator": "equal", "operand": "prompt.antiki" },
+		{ "key": "selector", "operator": "equal", "operand": "prompt.antiki" }
 	]},
 	{"keys": ["escape"], "command": "antiki_clear", "context": [
-		{ "key": "selector", "operator": "equal", "operand": "prompt.antiki" },
+		{ "key": "selector", "operator": "equal", "operand": "prompt.antiki" }
 	]},
 	{"keys": ["escape"], "command": "antiki_prev", "context": [
-		{ "key": "selector", "operator": "equal", "operand": "result.antiki" },
+		{ "key": "selector", "operator": "equal", "operand": "result.antiki" }
 	]}
 ]


### PR DESCRIPTION
Antiki was updated on Package Control, but its Default.sublime-keymap was not valid JSON: there was extra `,` after last element in the list.
This is fixed by this PR.

---

I have also tried out the Antiki mode, and there is another problem there: pressing Esc on command results makes the editor cursor disappear!  (I have not fixed this)
